### PR TITLE
help type inference figure out the right type for functions

### DIFF
--- a/examples/fn_as_arg.rs
+++ b/examples/fn_as_arg.rs
@@ -10,6 +10,5 @@ fn hello(name: String) {
 
 fn main() {
     let name = "Sam".to_owned();
-    let hello: fn(String) = hello;
-    eval((run, hello, name));
+    eval((run, hello as fn(_), name));
 }

--- a/examples/fn_as_arg.rs
+++ b/examples/fn_as_arg.rs
@@ -10,5 +10,6 @@ fn hello(name: String) {
 
 fn main() {
     let name = "Sam".to_owned();
-    eval((run, Box::new(hello), name));
+    let hello: fn(String) = hello;
+    eval((run, hello, name));
 }

--- a/examples/map_reduce.rs
+++ b/examples/map_reduce.rs
@@ -5,9 +5,20 @@ fn add_one(a: i32) -> i32 {
 }
 
 fn main() {
-    let v = vec![1, 2, 3];
-    let add_one: fn(i32) -> i32 = add_one;
-    let res = eval((map, add_one, v));
-    // let res = eval((reduce, 0, add, (map, add_one, vec![1, 2, 3])));
+    // Needs to be converted to function pointer
+    let add_one: fn(_) -> _ = add_one;
+    // let add_one = lambda(|a| a + 1);
+    // let add_one = lambda(add_one);
+    // let res = eval((map, add_one, vec![1, 2, 3]));
+
+    let add: fn(_, _) -> _ = add;
+    // let add = lambda2(add);
+    let res = eval((reduce, 0, add, (map, add_one, vec![1, 2, 3])));
+    // let res = eval((reduce, lazy(|| 0), add, (map, add_one, vec![1, 2, 3])));
+
+    // The following is an alternative that uses reduce2 and allows defining
+    // lambdas that accept any number of arguments by just using `lambda`.
+    // let add = lambda(|(r, e)| r + e);
+    // let res = eval((reduce2, 0, add, (map, add_one, vec![1, 2, 3])));
     println!("{:?}", res);
 }

--- a/examples/map_reduce.rs
+++ b/examples/map_reduce.rs
@@ -6,6 +6,7 @@ fn add_one(a: i32) -> i32 {
 
 fn main() {
     let v = vec![1, 2, 3];
+    let add_one: fn(i32) -> i32 = add_one;
     let res = eval((map, add_one, v));
     // let res = eval((reduce, 0, add, (map, add_one, vec![1, 2, 3])));
     println!("{:?}", res);

--- a/src/lisp/iter.rs
+++ b/src/lisp/iter.rs
@@ -16,6 +16,14 @@ where
     i.into_iter().fold(init, f)
 }
 
+pub fn reduce2<I, E, F, R>(init: R, mut f: F, i: I) -> R
+where
+    F: FnMut((R, E)) -> R,
+    I: IntoIterator<Item = E>,
+{
+    i.into_iter().fold(init, |r, e| f((r, e)))
+}
+
 pub fn to_vec<T, I>(i: I) -> Vec<T>
 where
     I: IntoIterator<Item = T>,

--- a/src/lisp/node.rs
+++ b/src/lisp/node.rs
@@ -95,16 +95,9 @@ impl<K, V> Node for HashMap<K, V> {
     }
 }
 
-impl<A, R> Node for Box<dyn Fn(A) -> R> {
+impl<A, R> Node for fn(A) -> R {
     type Return = Self;
     fn eval(self) -> Self::Return {
         self
-    }
-}
-
-impl<T> Node for Box<T> {
-    type Return = T;
-    fn eval(self) -> Self::Return {
-        *self
     }
 }


### PR DESCRIPTION
You can get rid of the `Box`-ed functions by helping the type inference a bit. Just done some tests, but the problem seems to be with the many steps of inference Rust needs to unify the types for functions. You can not use `.. where F: Fn(A) -> R` wothout `Box` as that'a trait object and needs to be `Sized`.